### PR TITLE
バーコードの削除処理を実装。（レシピの削除機能に関連付けを設定）

### DIFF
--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -75,6 +75,6 @@ class RecipesController < ApplicationController
   # barcodetags_attributesで、has_many関係にあるbarcodetagsの情報を受け取るようにする。これでbarcodetagsのアクションも同時に使える
   def recipe_params
     params.require(:recipe).permit(:title, :content, :time, :price, :calorie, :image,
-                                   barcodetags_attributes: [:barcode, :name,])
+                                   barcodetags_attributes: [:barcode, :name])
   end
 end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -1,8 +1,11 @@
 class Recipe < ApplicationRecord
   belongs_to :user
-  has_many :barcodetags
-  has_many :favorites
+  has_many :barcodetags, dependent: :destroy
+  has_many :favorites, dependent: :destroy
+  # dependent: :destroy= 親要素が削除されたら、子要素も削除されるようにするオプション
 
+  # barcodetags_attributesで、has_many関係にあるbarcodetagsの情報を受け取るようにする。
+  # これでbarcodetagsのアクションも同時に使える
   accepts_nested_attributes_for :barcodetags
 
   validates :title, presence: true, length: { maximum: 40 }


### PR DESCRIPTION
・ バーコード機能を追加したことでレシピの削除処理がエラーになっている。 
※バーコードの削除処理が無いためにエラーになる。
（レシピとバーコードを関連付けていたことで、バーコードを削除せずにレシピだけ削除しようとしたためにエラーになっている。）

Closes #28