### PR TITLE
お気に入りをカウントアクション（show_favorite_count）をユーザー認証をスキップするように修正。

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,4 +1,7 @@
 class FavoritesController < ApplicationController
+  # ユーザー認証をスキップする
+  skip_before_action :authenticate_user, only: [:show_favorite_count]
+
   # GET /favorites
   # 全てのお気に入りを取得し、JSON形式で返す
   def index


### PR DESCRIPTION
お気に入りをカウントアクション（show_favorite_count）をユーザー認証をスキップするように修正。
（ログアウトユーザーに対して、いいね数の表示がエラーになるため）