### PR TITLE
 レシピ入力項目の文字数制限を修正。 #58

### DIFF
--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -7,20 +7,31 @@ class Recipe < ApplicationRecord
   # 親要素と子要素を同時に作成・更新するための記述(allow_destroyはレシピ編集の際にタグの削除もするためのオプション)
   accepts_nested_attributes_for :tags, allow_destroy: true
 
-  validates :title, presence: true, length: { maximum: 40 }
-  validates :content, presence: true, length: { maximum: 1000 }
-  validates :image, presence: true
-  validates :calorie, length: { maximum: 9999 }
-  validates :price, length: { maximum: 9999 }
+  # presence: true= 空の値を許可しない
+  validates :title, presence: true, length: { maximum: 20 } # length: { maximum: 20 }= 20文字以内であることを確認する
+  validates :content, presence: true, length: { maximum: 500 } # length: { maximum: 500 }= 500文字以内であることを確認する
+  validates :image, presence: true # presence: true= 空の値を許可しない
+  validates :calorie, length: { maximum: 9999 } # length: { maximum: 9999 }= 9999文字以内であることを確認する
+  validates :price, length: { maximum: 9999 } # length: { maximum: 9999 }= 9999文字以内であることを確認する
 
   # タグの数が 5 以下であることを確認するカスタムバリデーションを追加
   validate :tags_count_within_limit
+  validate :tags_length_within_limit
 
   private
 
+  # タグの文字数が 15 以下であることを確認するカスタムバリデーション
+  def tags_length_within_limit
+    tags.each do |tag| # tags.each= tagsの中身を一つずつ取り出す
+      if tag.name.length > 15
+        errors.add(:tags, "は15文字までしか追加できません")
+      end
+    end
+  end
+
+  # タグの数が 5 以下であることを確認するカスタムバリデーション
   def tags_count_within_limit
-    puts tags
-    if tags.size > 10 # 削除５個＋追加５個＝最大１０個のリクエスト
+    if tags.size > 10 # 削除５個＋追加５個＝最大１０個のリクエスト(一時的に登録したタグ（ID無いもの）はカウントされないため最大１０個)
       errors.add(:tags, "は5個までしか追加できません")
     end
   end


### PR DESCRIPTION
レシピ入力項目の文字数制限を修正。 
タグの文字数が 15 以下であることを確認するカスタムバリデーションを追加
タイトルを２０文字以内に修正
作り方を５００文字以内に修正

Closes #58